### PR TITLE
feat: Add financial headlines service

### DIFF
--- a/services/financial-headlines/go.mod
+++ b/services/financial-headlines/go.mod
@@ -1,0 +1,3 @@
+module claude-20/services/financial-headlines
+
+go 1.21

--- a/services/financial-headlines/main.go
+++ b/services/financial-headlines/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"claude-20/services/financial-headlines/pkg/headlines"
+	"claude-20/services/financial-headlines/pkg/mcp"
+	"os"
+)
+
+func main() {
+	// Initialize services
+	headlinesService := headlines.NewService()
+	mcpHandler := mcp.NewHandler(headlinesService)
+
+	// Setup HTTP routes
+	http.Handle("/mcp", mcpHandler)
+	http.HandleFunc("/health", healthHandler)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8081" // Default port
+	}
+
+	// Start server
+	log.Printf("Starting MCP server on port %s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}

--- a/services/financial-headlines/pkg/headlines/service.go
+++ b/services/financial-headlines/pkg/headlines/service.go
@@ -1,0 +1,57 @@
+package headlines
+
+import (
+	"claude-20/services/financial-headlines/pkg/mcp"
+	"context"
+)
+
+type Service interface {
+	GetGeneralHeadlines(ctx context.Context, params mcp.GetGeneralHeadlinesParams) (*mcp.MCPToolCallResponse, error)
+	GetStockHeadlines(ctx context.Context, params mcp.GetStockHeadlinesParams) (*mcp.MCPToolCallResponse, error)
+	GetSectorHeadlines(ctx context.Context, params mcp.GetSectorHeadlinesParams) (*mcp.MCPToolCallResponse, error)
+	GetIndexHeadlines(ctx context.Context, params mcp.GetIndexHeadlinesParams) (*mcp.MCPToolCallResponse, error)
+}
+
+type service struct {
+	// In a real application, you might have dependencies like an API client.
+}
+
+func NewService() Service {
+	return &service{}
+}
+
+func (s *service) GetGeneralHeadlines(ctx context.Context, params mcp.GetGeneralHeadlinesParams) (*mcp.MCPToolCallResponse, error) {
+	headlines := []mcp.MCPContent{
+		{Type: "text", Text: "Global markets rally on positive economic data."},
+		{Type: "text", Text: "Tech stocks surge as new AI developments announced."},
+		{Type: "text", Text: "Federal Reserve hints at steady interest rates for the upcoming quarter."},
+	}
+	return &mcp.MCPToolCallResponse{Content: headlines}, nil
+}
+
+func (s *service) GetStockHeadlines(ctx context.Context, params mcp.GetStockHeadlinesParams) (*mcp.MCPToolCallResponse, error) {
+	headlines := []mcp.MCPContent{
+		{Type: "text", Text: "Ticker " + params.Ticker + " announces record profits, stock jumps 5%."},
+		{Type: "text", Text: "New product launch from " + params.Ticker + " receives mixed reviews."},
+		{Type: "text", Text: "Analyst upgrades " + params.Ticker + " to 'Buy' with a new price target."},
+	}
+	return &mcp.MCPToolCallResponse{Content: headlines}, nil
+}
+
+func (s *service) GetSectorHeadlines(ctx context.Context, params mcp.GetSectorHeadlinesParams) (*mcp.MCPToolCallResponse, error) {
+	headlines := []mcp.MCPContent{
+		{Type: "text", Text: "The " + params.Sector + " sector sees strong growth amid new government incentives."},
+		{Type: "text", Text: "Innovation in the " + params.Sector + " sector is driving investor confidence."},
+		{Type: "text", Text: "Consumer demand in the " + params.Sector + " sector remains robust."},
+	}
+	return &mcp.MCPToolCallResponse{Content: headlines}, nil
+}
+
+func (s *service) GetIndexHeadlines(ctx context.Context, params mcp.GetIndexHeadlinesParams) (*mcp.MCPToolCallResponse, error) {
+	headlines := []mcp.MCPContent{
+		{Type: "text", Text: "The " + params.Index + " reaches an all-time high as bull market continues."},
+		{Type: "text", Text: "Volatility in the " + params.Index + " increases ahead of earnings season."},
+		{Type: "text", Text: "The " + params.Index + " shows resilience despite global economic headwinds."},
+	}
+	return &mcp.MCPToolCallResponse{Content: headlines}, nil
+}

--- a/services/financial-headlines/pkg/mcp/handler.go
+++ b/services/financial-headlines/pkg/mcp/handler.go
@@ -1,0 +1,231 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type HeadlinesService interface {
+	GetGeneralHeadlines(ctx context.Context, params GetGeneralHeadlinesParams) (*MCPToolCallResponse, error)
+	GetStockHeadlines(ctx context.Context, params GetStockHeadlinesParams) (*MCPToolCallResponse, error)
+	GetSectorHeadlines(ctx context.Context, params GetSectorHeadlinesParams) (*MCPToolCallResponse, error)
+	GetIndexHeadlines(ctx context.Context, params GetIndexHeadlinesParams) (*MCPToolCallResponse, error)
+}
+
+type Handler struct {
+	headlinesService HeadlinesService
+}
+
+func NewHandler(headlinesService HeadlinesService) *Handler {
+	return &Handler{
+		headlinesService: headlinesService,
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	var req JSONRPCRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.sendError(w, nil, -32700, "Parse error", err.Error())
+		return
+	}
+
+	if req.JSONRPC != "2.0" {
+		h.sendError(w, req.ID, -32600, "Invalid Request", "jsonrpc must be '2.0'")
+		return
+	}
+
+	ctx := r.Context()
+
+	switch req.Method {
+	case "initialize":
+		h.handleInitialize(w, req)
+	case "notifications/initialized":
+		h.handleNotificationsInitialized(w, req)
+	case "ping":
+		h.handlePing(w, req)
+	case "tools/list":
+		h.handleToolsList(w, req)
+	case "tools/call":
+		h.handleToolsCall(w, req, ctx)
+	default:
+		h.sendError(w, req.ID, -32601, "Method not found", fmt.Sprintf("Unknown method: %s", req.Method))
+	}
+}
+
+func (h *Handler) handleInitialize(w http.ResponseWriter, req JSONRPCRequest) {
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"capabilities": map[string]interface{}{
+				"tools": map[string]interface{}{
+					"listChanged": false,
+				},
+			},
+			"serverInfo": map[string]interface{}{
+				"name":    "financial-headlines",
+				"version": "1.0.0",
+			},
+		},
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *Handler) handleNotificationsInitialized(w http.ResponseWriter, req JSONRPCRequest) {
+	responseID := req.ID
+	if responseID == nil {
+		responseID = 0
+	}
+
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      responseID,
+		Result:  map[string]interface{}{},
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *Handler) handlePing(w http.ResponseWriter, req JSONRPCRequest) {
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  map[string]interface{}{},
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *Handler) handleToolsList(w http.ResponseWriter, req JSONRPCRequest) {
+	tools := []MCPTool{
+		{
+			Name:        "get_general_headlines",
+			Description: "Get general financial market headlines",
+			InputSchema: GetGeneralHeadlinesSchema,
+		},
+		{
+			Name:        "get_stock_headlines",
+			Description: "Get financial headlines for a specific stock ticker",
+			InputSchema: GetStockHeadlinesSchema,
+		},
+		{
+			Name:        "get_sector_headlines",
+			Description: "Get financial headlines for a specific market sector",
+			InputSchema: GetSectorHeadlinesSchema,
+		},
+		{
+			Name:        "get_index_headlines",
+			Description: "Get financial headlines for a specific market index",
+			InputSchema: GetIndexHeadlinesSchema,
+		},
+	}
+
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  MCPToolsListResponse{Tools: tools},
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *Handler) handleToolsCall(w http.ResponseWriter, req JSONRPCRequest, ctx context.Context) {
+	var toolCallReq MCPToolsCallRequest
+	if err := json.Unmarshal([]byte(fmt.Sprintf(`{
+		"jsonrpc": "%s",
+		"id": %v,
+		"method": "%s",
+		"params": %s
+	}`, req.JSONRPC, req.ID, req.Method, mustMarshal(req.Params))), &toolCallReq); err != nil {
+		h.sendError(w, req.ID, -32602, "Invalid params", err.Error())
+		return
+	}
+
+	var result *MCPToolCallResponse
+	var err error
+
+	switch toolCallReq.Params.Name {
+	case "get_general_headlines":
+		var params GetGeneralHeadlinesParams
+		result, err = h.headlinesService.GetGeneralHeadlines(ctx, params)
+
+	case "get_stock_headlines":
+		var params GetStockHeadlinesParams
+		if err := mapToStruct(toolCallReq.Params.Arguments, &params); err != nil {
+			h.sendError(w, req.ID, -32602, "Invalid params", err.Error())
+			return
+		}
+		result, err = h.headlinesService.GetStockHeadlines(ctx, params)
+
+	case "get_sector_headlines":
+		var params GetSectorHeadlinesParams
+		if err := mapToStruct(toolCallReq.Params.Arguments, &params); err != nil {
+			h.sendError(w, req.ID, -32602, "Invalid params", err.Error())
+			return
+		}
+		result, err = h.headlinesService.GetSectorHeadlines(ctx, params)
+
+	case "get_index_headlines":
+		var params GetIndexHeadlinesParams
+		if err := mapToStruct(toolCallReq.Params.Arguments, &params); err != nil {
+			h.sendError(w, req.ID, -32602, "Invalid params", err.Error())
+			return
+		}
+		result, err = h.headlinesService.GetIndexHeadlines(ctx, params)
+
+	default:
+		h.sendError(w, req.ID, -32601, "Method not found", fmt.Sprintf("Unknown tool: %s", toolCallReq.Params.Name))
+		return
+	}
+
+	if err != nil {
+		h.sendError(w, req.ID, -32603, "Internal error", err.Error())
+		return
+	}
+
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  result,
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *Handler) sendError(w http.ResponseWriter, id interface{}, code int, message, data string) {
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &JSONRPCError{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+func mapToStruct(m map[string]interface{}, result interface{}) error {
+	jsonBytes, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(jsonBytes, result)
+}
+
+func mustMarshal(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}

--- a/services/financial-headlines/pkg/mcp/types.go
+++ b/services/financial-headlines/pkg/mcp/types.go
@@ -1,0 +1,109 @@
+package mcp
+
+import "encoding/json"
+
+// Standard JSON-RPC 2.0 types
+type JSONRPCRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string        `json:"jsonrpc"`
+	ID      interface{}   `json:"id"`
+	Result  interface{}   `json:"result,omitempty"`
+	Error   *JSONRPCError `json:"error,omitempty"`
+}
+
+type JSONRPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// MCP Protocol types
+type MCPToolsListRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Method  string      `json:"method"` // Should be "tools/list"
+}
+
+type MCPToolsCallRequest struct {
+	JSONRPC string            `json:"jsonrpc"`
+	ID      interface{}       `json:"id"`
+	Method  string            `json:"method"` // Should be "tools/call"
+	Params  MCPToolCallParams `json:"params"`
+}
+
+type MCPToolCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+type MCPTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+type MCPToolsListResponse struct {
+	Tools []MCPTool `json:"tools"`
+}
+
+type MCPToolCallResponse struct {
+	Content []MCPContent `json:"content"`
+	IsError bool         `json:"isError,omitempty"`
+}
+
+type MCPContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// Tool parameter types
+type GetGeneralHeadlinesParams struct{}
+
+type GetStockHeadlinesParams struct {
+	Ticker string `json:"ticker"`
+}
+
+type GetSectorHeadlinesParams struct {
+	Sector string `json:"sector"`
+}
+
+type GetIndexHeadlinesParams struct {
+	Index string `json:"index"`
+}
+
+// Tool schemas
+var GetGeneralHeadlinesSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {},
+	"required": []
+}`)
+
+var GetStockHeadlinesSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"ticker": {"type": "string", "description": "Stock ticker symbol (e.g., AAPL)"}
+	},
+	"required": ["ticker"]
+}`)
+
+var GetSectorHeadlinesSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"sector": {"type": "string", "description": "Market sector (e.g., Technology)"}
+	},
+	"required": ["sector"]
+}`)
+
+var GetIndexHeadlinesSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"index": {"type": "string", "description": "Market index (e.g., S&P 500)"}
+	},
+	"required": ["index"]
+}`)

--- a/services/financial-headlines/start_server.sh
+++ b/services/financial-headlines/start_server.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+go run main.go


### PR DESCRIPTION
This commit introduces a new service for retrieving financial headlines. The service is implemented in Go and exposed through several new functions, following the same structure as the existing portfolio-db service.

The new service, located in `services/financial-headlines`, provides the following functions:
- `get_general_headlines`: Get general financial market headlines.
- `get_stock_headlines`: Get headlines for a specific stock ticker.
- `get_sector_headlines`: Get headlines for a specific market sector.
- `get_index_headlines`: Get headlines for a specific market index.

The service uses a mock implementation that returns hardcoded headlines, as no real financial data API is available in the current environment.

Verification:
- The service was compiled successfully.
- An import cycle was identified and fixed.
- The server was started and ran without crashing.

Full end-to-end testing with `curl` was attempted but blocked by a persistent timeout issue when running a background server process. Despite multiple workarounds, it was not possible to test the running server's endpoints. However, based on the successful compilation and server startup, there is high confidence in the correctness of the implementation.